### PR TITLE
Fix/changes font size for long tweets

### DIFF
--- a/src/static/css/global/variables.scss
+++ b/src/static/css/global/variables.scss
@@ -14,12 +14,12 @@ $dark-base3: rgba(255, 255, 255, .2);
 $dark-accent1: #1DA1F2;
 
 /* font-size for layout-16x9 */
-$l-text-16x9: 5vw;
+$l-text-16x9: 4.5vw;
 $m-text-16x9: 3.5vw;
 $s-text-16x9: 2.5vw;
 
 /* font-size for layout-4x3 */
-$xl-text-4x3: 5.5vw;
+$xl-text-4x3: 5vw;
 $l-text-4x3: 5vw;
 $m-text-4x3: 4vw;
 $s-text-4x3: 3.75vw;


### PR DESCRIPTION
Tested for all three layouts. 9x16 doesn't need a change for now because it's unaffected by this bug. 