### PR TITLE
Chore/Downgrade unnecessary errors to warnings

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -25,6 +25,11 @@ export default class Logger {
     this._external(evt, eventDetails);
   }
 
+  warning(eventDetails, data) {
+    console.log(eventDetails);
+    this._external('warning', eventDetails, data);
+  }
+
   error(eventDetails, data) {
     console.log(eventDetails);
     this._external('Error', eventDetails, data);

--- a/src/rise-twitter.js
+++ b/src/rise-twitter.js
@@ -125,7 +125,7 @@ export default class RiseTwitter extends HTMLElement {
     }
 
     if (!this.screenName) {
-      this.logger.error('Error: screenName is missing');
+      this.logger.warning('screen_name is missing');
       this.eventHandler.emitDone();
     }
   }

--- a/src/tweet.js
+++ b/src/tweet.js
@@ -41,7 +41,7 @@ export default class Tweet {
           this.eventHandler.emitDone();
         });
     } else {
-      if (this.logger) {this.logger.error(`Invalid Tweets - ${JSON.stringify(tweets)}`);}
+      if (this.logger) {this.logger.warning(`invalid tweets - ${JSON.stringify(tweets)}`);}
       this.eventHandler.emitDone();
     }
   }


### PR DESCRIPTION
Both cases are handled (or will be handled by future cards) by fallbacks so they should be warnings:
- "Invalid Tweets" error message when we are supplied an invalid screen name, a screen name with 0 tweets / only tweets with images. Downgrade to warning since we show filler tweets in such cases
- 'screenName is missing'
