### PR TITLE
Prevent processing logs to client-side-events

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build-stage": "NODE_ENV=stage node build/build.js"
   },
   "dependencies": {
-    "common-component": "git+https://github.com/Rise-Vision/common-component.git#v1.17.0",
+    "common-component": "git+https://github.com/Rise-Vision/common-component.git#v1.19.0",
     "jquery": "^3.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description
Prevent the flow of processing sending logs to client-side-events project by using latest common-component. See https://github.com/Rise-Vision/common-component/pull/42 for changes. 

## Motivation and Context
https://github.com/Rise-Vision/widget-common/issues/168

## How Has This Been Tested?
Tested with local version of rise-twitter via Charles Proxy in a presentation on ChrOS player. Validated no logs to `Component_Events. rise_twitter_events` were inserted. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
no
